### PR TITLE
chore: ci 스크립트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI with Gradle
+
+on:
+  pull_request:
+    branches: [ "develop", "release", "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: "**/build/test-results/**/*.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,3 @@ jobs:
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build
-
-      - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: "**/build/test-results/**/*.xml"

--- a/src/main/java/com/example/solidconnection/auth/client/AppleOAuthClientSecretProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/client/AppleOAuthClientSecretProvider.java
@@ -35,7 +35,7 @@ public class AppleOAuthClientSecretProvider {
 
     @PostConstruct
     private void initPrivateKey() {
-        privateKey = readPrivateKey();
+        privateKey = generatePrivateKey();
     }
 
     public String generateClientSecret() {
@@ -53,7 +53,7 @@ public class AppleOAuthClientSecretProvider {
                 .compact();
     }
 
-    private PrivateKey readPrivateKey() {
+    private PrivateKey generatePrivateKey() {
         try {
             String secretKey = appleOAuthClientProperties.secretKey();
             byte[] encoded = Base64.decodeBase64(secretKey);

--- a/src/main/java/com/example/solidconnection/auth/client/AppleOAuthClientSecretProvider.java
+++ b/src/main/java/com/example/solidconnection/auth/client/AppleOAuthClientSecretProvider.java
@@ -19,7 +19,7 @@ import java.util.Date;
 import static com.example.solidconnection.custom.exception.ErrorCode.FAILED_TO_READ_APPLE_PRIVATE_KEY;
 
 /*
- * 애플 OAuth 에 필요하 클라이언트 시크릿은 매번 동적으로 생성해야 한다.
+ * 애플 OAuth 에 필요한 클라이언트 시크릿은 매번 동적으로 생성해야 한다.
  * 클라이언트 시크릿은 애플 개발자 계정에서 발급받은 개인키(*.p8)를 사용하여 JWT 를 생성한다.
  * https://developer.apple.com/documentation/accountorganizationaldatasharing/creating-a-client-secret
  * */

--- a/src/main/java/com/example/solidconnection/config/client/AppleOAuthClientProperties.java
+++ b/src/main/java/com/example/solidconnection/config/client/AppleOAuthClientProperties.java
@@ -10,6 +10,7 @@ public record AppleOAuthClientProperties(
         String publicKeyUrl,
         String clientId,
         String teamId,
-        String keyId
+        String keyId,
+        String secretKey
 ) {
 }

--- a/src/test/java/com/example/solidconnection/community/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/example/solidconnection/community/comment/service/CommentServiceTest.java
@@ -71,8 +71,10 @@ class CommentServiceTest extends BaseIntegrationTest {
                                     () -> assertThat(response.parentId()).isNull(),
                                     () -> assertThat(response.content()).isEqualTo(parentComment.getContent()),
                                     () -> assertThat(response.isOwner()).isTrue(),
-                                    () -> assertThat(response.createdAt()).isEqualTo(parentComment.getCreatedAt()),
-                                    () -> assertThat(response.updatedAt()).isEqualTo(parentComment.getUpdatedAt()),
+                                    () -> assertThat(response.createdAt().withNano(0))
+                                            .isEqualTo(parentComment.getCreatedAt().withNano(0)),
+                                    () -> assertThat(response.updatedAt().withNano(0))
+                                            .isEqualTo(parentComment.getUpdatedAt().withNano(0)),
 
                                     () -> assertThat(response.postFindSiteUserResponse().id())
                                             .isEqualTo(parentComment.getSiteUser().getId()),
@@ -89,8 +91,10 @@ class CommentServiceTest extends BaseIntegrationTest {
                                     () -> assertThat(response.parentId()).isEqualTo(parentComment.getId()),
                                     () -> assertThat(response.content()).isEqualTo(childComment.getContent()),
                                     () -> assertThat(response.isOwner()).isFalse(),
-                                    () -> assertThat(response.createdAt()).isEqualTo(childComment.getCreatedAt()),
-                                    () -> assertThat(response.updatedAt()).isEqualTo(childComment.getUpdatedAt()),
+                                    () -> assertThat(response.createdAt().withNano(0))
+                                            .isEqualTo(childComment.getCreatedAt().withNano(0)),
+                                    () -> assertThat(response.updatedAt().withNano(0))
+                                            .isEqualTo(childComment.getUpdatedAt().withNano(0)),
 
                                     () -> assertThat(response.postFindSiteUserResponse().id())
                                             .isEqualTo(childComment.getSiteUser().getId()),

--- a/src/test/java/com/example/solidconnection/database/DatabaseConnectionTest.java
+++ b/src/test/java/com/example/solidconnection/database/DatabaseConnectionTest.java
@@ -8,7 +8,6 @@ import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -20,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Disabled
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2, replace = AutoConfigureTestDatabase.Replace.ANY)
-@ActiveProfiles("test")
 @DataJpaTest
 class DatabaseConnectionTest {
 

--- a/src/test/java/com/example/solidconnection/database/RedisConnectionTest.java
+++ b/src/test/java/com/example/solidconnection/database/RedisConnectionTest.java
@@ -6,12 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Disabled
-@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class RedisConnectionTest {
 

--- a/src/test/java/com/example/solidconnection/support/DatabaseCleaner.java
+++ b/src/test/java/com/example/solidconnection/support/DatabaseCleaner.java
@@ -5,13 +5,11 @@ import jakarta.persistence.PersistenceContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
 
-@ActiveProfiles("test")
 @Component
 public class DatabaseCleaner {
 

--- a/src/test/java/com/example/solidconnection/support/TestContainerDataJpaTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerDataJpaTest.java
@@ -3,7 +3,6 @@ package com.example.solidconnection.support;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.ElementType;
@@ -13,7 +12,6 @@ import java.lang.annotation.Target;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
 @Testcontainers
 @Import(MySQLTestContainer.class)
 @Target(ElementType.TYPE)

--- a/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.ElementType;
@@ -12,10 +13,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @ExtendWith({DatabaseClearExtension.class})
+@ContextConfiguration(initializers = RedisTestContainer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers
-@Import({MySQLTestContainer.class, RedisTestContainer.class})
+@Import({MySQLTestContainer.class})
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TestContainerSpringBootTest {

--- a/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
+++ b/src/test/java/com/example/solidconnection/support/TestContainerSpringBootTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.ElementType;
@@ -15,7 +14,6 @@ import java.lang.annotation.Target;
 @ExtendWith({DatabaseClearExtension.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
 @Testcontainers
 @Import({MySQLTestContainer.class, RedisTestContainer.class})
 @Target(ElementType.TYPE)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,7 +7,7 @@ spring:
       port: 6379
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     generate-ddl: true
     show-sql: true
     database: mysql

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,72 @@
+spring:
+
+# db
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    generate-ddl: true
+    show-sql: true
+    database: mysql
+    properties:
+      hibernate:
+        format_sql: true
+  flyway:
+    enabled: false
+
+# cloud
+cloud:
+  aws:
+    credentials:
+      access-key: access-key
+      secret-key: access-key
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    s3:
+      bucket: solid-connection-uploaded
+      url:
+        default: default-url
+        uploaded: uploaded-url
+    cloudFront:
+      url:
+        default: default-url
+        uploaded: uploaded-url
+
+# variable
+view:
+  count:
+    scheduling:
+      delay: 3000
+oauth:
+  apple:
+    token-url: "https://appleid.apple.com/auth/token"
+    client-secret-audience-url: "https://appleid.apple.com"
+    public-key-url: "https://appleid.apple.com/auth/keys"
+    client-id: client-id
+    team-id: team-id
+    key-id: key-id
+    redirect-url: "https://localhost:8080/auth/apple"
+  kakao:
+    redirect-url: "http://localhost:8080/auth/kakao"
+    client-id: client-id
+    token-url: "https://kauth.kakao.com/oauth/token"
+    user-info_url: "https://kapi.kakao.com/v2/user/me"
+sentry:
+  environment: test
+  dsn: "https://test-public-key@sentry.test-domain.io/123456"
+  send-default-pii: true
+  traces-sample-rate: 1.0
+  exception-resolver-order: -2147483647
+university:
+  term: 2024-1
+jwt:
+  secret:
+    1234567-1234-1234-1234-12345678901
+cors:
+  allowed-origins:
+    - "http://localhost:8080"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -51,7 +51,8 @@ oauth:
     team-id: team-id
     key-id: key-id
     redirect-url: "https://localhost:8080/auth/apple"
-  kakao:
+    secret-key: MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCAfGIQ3TtNYAZG7i3m72odmdhfymkM9wAFg2rEL2RKUEA==
+kakao:
     redirect-url: "http://localhost:8080/auth/kakao"
     client-id: client-id
     token-url: "https://kauth.kakao.com/oauth/token"


### PR DESCRIPTION
### **User description**
## 관련 이슈

- resolves: #이슈 번호

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->


___

### **PR Type**
Enhancement, Tests, Configuration changes


___

### **Description**
- Refactored `AppleOAuthClientSecretProvider` to use `secretKey` from properties.

- Added a new `secretKey` field to `AppleOAuthClientProperties`.

- Removed `@ActiveProfiles("test")` annotations from test classes.

- Updated Redis test container configuration for better integration.

- Added a CI workflow using GitHub Actions for Gradle builds.

- Introduced a new `application.yml` for test configurations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>AppleOAuthClientSecretProvider.java</strong><dd><code>Refactored to use `secretKey` from properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-1280afce6bd941c9a3e4df79b1154a9ed94729cad7520b7999b89037e3806f60">+8/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AppleOAuthClientProperties.java</strong><dd><code>Added `secretKey` field to properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-b326b3da8681cc7eb30b11c5156994251dc633fe2ab1098275b5d42c4e475a46">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>DatabaseConnectionTest.java</strong><dd><code>Removed `@ActiveProfiles("test")` annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-8e7f9a4eef849cd0c8a2edac69347f9acc149d8b4a6afbce92f13dac6b9a24ea">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RedisConnectionTest.java</strong><dd><code>Removed `@ActiveProfiles("test")` annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-28e0c3d9b23c6f653eef736f99c8ccd4bd04e55cae71c340d2b24a439c833a42">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DatabaseCleaner.java</strong><dd><code>Removed `@ActiveProfiles("test")` annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-608586c390f57b255a1365a4f6619456db52106a182db3a7ed742467cc9a7c7f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RedisTestContainer.java</strong><dd><code>Updated Redis test container configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-f043336cff4f65bffd87960a3b0a6246898f0bb053a9ebeb2909b9a9adb3ceba">+15/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TestContainerDataJpaTest.java</strong><dd><code>Removed `@ActiveProfiles("test")` annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-3de8e30b3c5bdf7b26a03299bf6c6a814bb6b1fe6ca7e4244729f8a6bcb83b6e">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TestContainerSpringBootTest.java</strong><dd><code>Updated Redis container initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-09465683dacb0378bd8f89946c4c7fc31107d3b034cb2dea4d97739f80b038d2">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ci.yml</strong><dd><code>Added CI workflow for Gradle builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application.yml</strong><dd><code>Added test-specific application configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nayonsoso/solid-connect-fork/pull/6/files#diff-9505534937cc795b823f36b038529b4a0fc1cc060b9c14df770504a187e6ef69">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration file for the Spring application, enhancing settings related to database, cloud, OAuth, Sentry, and CORS.
  - Updated the method for generating the Apple OAuth client secret, improving security and error handling.
- **Chores**
  - Implemented a new GitHub Actions workflow for automated continuous integration, enhancing build and test processes.
  - Restructured Redis container initialization for improved efficiency in testing environments.
- **Bug Fixes**
  - Modified timestamp assertions in comment service tests to ensure accurate comparisons.
- **Refactor**
  - Removed unnecessary annotations from various test classes, streamlining the testing configuration.
  - Added a new field for the Apple OAuth client properties to accommodate additional configuration needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->